### PR TITLE
Fix: Crash ante discrepancia de orden de `identifier` entre`ExprEquals` y FROM

### DIFF
--- a/src/query/optimizer/optimizer.cc
+++ b/src/query/optimizer/optimizer.cc
@@ -211,8 +211,13 @@ void Optimizer::visit(JoinPlan& join) {
         }
 
         for (auto& col_pair : join.join_columns) {
-            auto lhs_col = col_pair.first;
-            auto rhs_col = col_pair.second;
+			if (lhs_cols.size() == 0 || rhs_cols.size() == 0) {
+				break;
+			}
+
+			bool swap = col_pair.first.alias == rhs_cols[0].alias;
+			auto lhs_col = swap ? col_pair.second : col_pair.first;
+			auto rhs_col = swap ? col_pair.first : col_pair.second;
 
             int lhs_col_pos = -1;
             int rhs_col_pos = -1;

--- a/src/query/optimizer/optimizer.cc
+++ b/src/query/optimizer/optimizer.cc
@@ -211,13 +211,13 @@ void Optimizer::visit(JoinPlan& join) {
         }
 
         for (auto& col_pair : join.join_columns) {
-			if (lhs_cols.size() == 0 || rhs_cols.size() == 0) {
-				break;
-			}
+            if (lhs_cols.size() == 0 || rhs_cols.size() == 0) {
+                break;
+            }
 
-			bool swap = col_pair.first.alias == rhs_cols[0].alias;
-			auto lhs_col = swap ? col_pair.second : col_pair.first;
-			auto rhs_col = swap ? col_pair.first : col_pair.second;
+            bool swap = col_pair.first.alias == rhs_cols[0].alias;
+            auto lhs_col = swap ? col_pair.second : col_pair.first;
+            auto rhs_col = swap ? col_pair.first : col_pair.second;
 
             int lhs_col_pos = -1;
             int rhs_col_pos = -1;


### PR DESCRIPTION
Hola! Este PR busca arreglar un crash de la aplicación que surge cuando se tienen identificadores dentro de una expresión de igualdad en un orden inverso al de los hijos de un `JoinPlan`. Aca hay un ejemplo minimo reproducible.

![Screenshot from 2024-07-04 18-56-04](https://github.com/DiegoEmilio01/IIC3413/assets/37167978/b295f794-2a72-40fe-ac8e-63d57d4951e7)

![Screenshot from 2024-07-04 18-55-04](https://github.com/DiegoEmilio01/IIC3413/assets/37167978/81ec22ba-c0aa-4d10-bf25-bf30f1d3fe65)

